### PR TITLE
Improve selector extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,18 @@ Alternatively, you can use the npm start script:
 npm start -- <url>
 ```
 
-The script prints a list of selectors to standard output.
+The script prints selectors grouped by how they were discovered. Output will
+resemble the following structure:
+
+```json
+{
+  "ids": ["#main"],
+  "testIds": ["[data-testid=\"header\"]"],
+  "names": ["input[name=\"search\"]"],
+  "text": ["button:has-text(\"Submit\")"],
+  "all": ["#main", "[data-testid=\"header\"]", ...]
+}
+```
 
 ## Example
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,40 +1,76 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.extractSelectors = extractSelectors;
 const playwright_1 = require("playwright");
+/**
+ * Extracts DOM selectors from the given URL. The selectors are grouped by
+ * the attribute or strategy used to locate them. Any error will result in an
+ * empty set of selectors but the browser will always close.
+ */
 async function extractSelectors(url) {
     const browser = await playwright_1.chromium.launch();
     const page = await browser.newPage();
-    await page.goto(url);
-    // Collect selectors
-    const selectors = await page.evaluate(() => {
-        const results = [];
-        const elements = Array.from(document.querySelectorAll('*'));
-        for (const el of elements) {
-            if (el.id) {
-                results.push(`#${el.id}`);
-                continue;
+    try {
+        await page.goto(url);
+        // Collect selectors grouped by strategy inside the browser context
+        const groups = await page.evaluate(() => {
+            const ids = [];
+            const testIds = [];
+            const names = [];
+            const text = [];
+            const all = [];
+            const elements = Array.from(document.querySelectorAll('*'));
+            for (const el of elements) {
+                if (el.id) {
+                    const sel = `#${el.id}`;
+                    ids.push(sel);
+                    all.push(sel);
+                    continue;
+                }
+                const testid = el.getAttribute('data-testid');
+                if (testid) {
+                    const sel = `[data-testid="${testid}"]`;
+                    testIds.push(sel);
+                    all.push(sel);
+                    continue;
+                }
+                const name = el.getAttribute('name');
+                if (name) {
+                    const sel = `${el.tagName.toLowerCase()}[name="${name}"]`;
+                    names.push(sel);
+                    all.push(sel);
+                    continue;
+                }
+                const innerText = el.innerText.trim();
+                if (innerText && innerText.length < 30) {
+                    // Normalize multi-line text to a single line for stability
+                    const trimmed = innerText.replace(/\n+/g, ' ').trim();
+                    const sel = `${el.tagName.toLowerCase()}:has-text(\"${trimmed}\")`;
+                    text.push(sel);
+                    all.push(sel);
+                }
             }
-            const testid = el.getAttribute('data-testid');
-            if (testid) {
-                results.push(`[data-testid="${testid}"]`);
-                continue;
-            }
-            const name = el.getAttribute('name');
-            if (name) {
-                results.push(`${el.tagName.toLowerCase()}[name="${name}"]`);
-                continue;
-            }
-            const text = el.innerText.trim();
-            if (text && text.length < 30) {
-                const trimmed = text.replace(/\n+/g, ' ').trim();
-                results.push(`${el.tagName.toLowerCase()}:has-text(\"${trimmed}\")`);
-            }
-        }
-        return Array.from(new Set(results));
-    });
-    await browser.close();
-    return selectors;
+            // Remove duplicates and return grouped selectors
+            const unique = (arr) => Array.from(new Set(arr));
+            return {
+                ids: unique(ids),
+                testIds: unique(testIds),
+                names: unique(names),
+                text: unique(text),
+                all: unique(all),
+            };
+        });
+        return groups;
+    }
+    catch {
+        // If any error occurs we return empty groups to avoid throwing
+        return { ids: [], testIds: [], names: [], text: [], all: [] };
+    }
+    finally {
+        await browser.close();
+    }
 }
+// Simple CLI entry point when the file is executed directly
 (async () => {
     const url = process.argv[2];
     if (!url) {
@@ -42,8 +78,6 @@ async function extractSelectors(url) {
         process.exit(1);
     }
     const selectors = await extractSelectors(url);
-    console.log('Extracted selectors:\n');
-    for (const sel of selectors) {
-        console.log(sel);
-    }
+    console.log('Extracted selectors grouped by strategy:\n');
+    console.log(JSON.stringify(selectors, null, 2));
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,40 +1,95 @@
 import { chromium } from 'playwright';
 
-async function extractSelectors(url: string) {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
-  await page.goto(url);
-  // Collect selectors
-  const selectors = await page.evaluate(() => {
-    const results: string[] = [];
-    const elements = Array.from(document.querySelectorAll('*')) as HTMLElement[];
-    for (const el of elements) {
-      if (el.id) {
-        results.push(`#${el.id}`);
-        continue;
-      }
-      const testid = el.getAttribute('data-testid');
-      if (testid) {
-        results.push(`[data-testid="${testid}"]`);
-        continue;
-      }
-      const name = el.getAttribute('name');
-      if (name) {
-        results.push(`${el.tagName.toLowerCase()}[name="${name}"]`);
-        continue;
-      }
-      const text = el.innerText.trim();
-      if (text && text.length < 30) {
-        const trimmed = text.replace(/\n+/g, ' ').trim();
-        results.push(`${el.tagName.toLowerCase()}:has-text(\"${trimmed}\")`);
-      }
-    }
-    return Array.from(new Set(results));
-  });
-  await browser.close();
-  return selectors;
+/**
+ * Represents the grouped selectors extracted from a page.
+ */
+export interface SelectorGroups {
+  /** Selectors that target elements by id attribute. */
+  ids: string[];
+  /** Selectors that target elements by data-testid attribute. */
+  testIds: string[];
+  /** Selectors that target elements by name attribute. */
+  names: string[];
+  /** Selectors derived from visible text content. */
+  text: string[];
+  /** All selectors combined without duplicates. */
+  all: string[];
 }
 
+/**
+ * Extracts DOM selectors from the given URL. The selectors are grouped by
+ * the attribute or strategy used to locate them. Any error will result in an
+ * empty set of selectors but the browser will always close.
+ */
+export async function extractSelectors(url: string): Promise<SelectorGroups> {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  try {
+    await page.goto(url);
+    // Collect selectors grouped by strategy inside the browser context
+    const groups = await page.evaluate(() => {
+      const ids: string[] = [];
+      const testIds: string[] = [];
+      const names: string[] = [];
+      const text: string[] = [];
+      const all: string[] = [];
+
+      const elements = Array.from(document.querySelectorAll('*')) as HTMLElement[];
+      for (const el of elements) {
+        if (el.id) {
+          const sel = `#${el.id}`;
+          ids.push(sel);
+          all.push(sel);
+          continue;
+        }
+
+        const testid = el.getAttribute('data-testid');
+        if (testid) {
+          const sel = `[data-testid="${testid}"]`;
+          testIds.push(sel);
+          all.push(sel);
+          continue;
+        }
+
+        const name = el.getAttribute('name');
+        if (name) {
+          const sel = `${el.tagName.toLowerCase()}[name="${name}"]`;
+          names.push(sel);
+          all.push(sel);
+          continue;
+        }
+
+        const innerText = el.innerText.trim();
+        if (innerText && innerText.length < 30) {
+          // Normalize multi-line text to a single line for stability
+          const trimmed = innerText.replace(/\n+/g, ' ').trim();
+          const sel = `${el.tagName.toLowerCase()}:has-text(\"${trimmed}\")`;
+          text.push(sel);
+          all.push(sel);
+        }
+      }
+
+      // Remove duplicates and return grouped selectors
+      const unique = (arr: string[]) => Array.from(new Set(arr));
+      return {
+        ids: unique(ids),
+        testIds: unique(testIds),
+        names: unique(names),
+        text: unique(text),
+        all: unique(all),
+      };
+    });
+
+    return groups;
+  } catch {
+    // If any error occurs we return empty groups to avoid throwing
+    return { ids: [], testIds: [], names: [], text: [], all: [] };
+  } finally {
+    await browser.close();
+  }
+}
+
+// Simple CLI entry point when the file is executed directly
 (async () => {
   const url = process.argv[2];
   if (!url) {
@@ -42,8 +97,6 @@ async function extractSelectors(url: string) {
     process.exit(1);
   }
   const selectors = await extractSelectors(url);
-  console.log('Extracted selectors:\n');
-  for (const sel of selectors) {
-    console.log(sel);
-  }
+  console.log('Extracted selectors grouped by strategy:\n');
+  console.log(JSON.stringify(selectors, null, 2));
 })();


### PR DESCRIPTION
## Summary
- support grouping of selectors by discovery method
- add bulletproof error handling and more comments
- document grouped output in README

## Testing
- `npm test` *(fails: Cannot find module 'playwright')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842ac13909c8330986f9e35bee507e9