### PR TITLE
Fix TS build errors by adding Node types

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "playwright": "^1.43.1"
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "@types/node": "^20.10.6"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,9 @@
     "module": "commonjs",
     "outDir": "dist",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["node"],
+    "lib": ["esnext", "DOM"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- add `@types/node` so Node globals compile
- reference Node types and modern libs in `tsconfig.json`

## Testing
- `npm install` *(fails: 403 Forbidden for @types/node)*
- `npm run build` *(fails: cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6842aecfe1848330a28c1a4ae2873deb