### PR TITLE
Refactor selector extraction and add typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/dist/index.js
+++ b/dist/index.js
@@ -28,6 +28,118 @@ catch {
         cyan: (s) => s,
     };
 }
+function collectSelectors() {
+    const ids = [];
+    const testIds = [];
+    const names = [];
+    const roles = [];
+    const text = [];
+    const all = [];
+    const pageObj = {};
+    const camel = (str) => str.toLowerCase().replace(/[^a-z0-9]+(.)/g, (_, chr) => chr.toUpperCase());
+    function defaultRole(el) {
+        const tag = el.tagName.toLowerCase();
+        switch (tag) {
+            case 'a':
+                return 'link';
+            case 'button':
+                return 'button';
+            case 'select':
+                return 'combobox';
+            case 'option':
+                return 'option';
+            case 'input': {
+                const type = (el.getAttribute('type') || '').toLowerCase();
+                switch (type) {
+                    case 'checkbox':
+                        return 'checkbox';
+                    case 'radio':
+                        return 'radio';
+                    case 'submit':
+                    case 'button':
+                        return 'button';
+                    default:
+                        return 'textbox';
+                }
+            }
+            default:
+                return null;
+        }
+    }
+    const elements = Array.from(document.querySelectorAll('*'));
+    let index = 0;
+    for (const el of elements) {
+        let sel = '';
+        let keyBase = '';
+        if (el.id) {
+            sel = `#${el.id}`;
+            ids.push(sel);
+            keyBase = el.id;
+        }
+        else {
+            const testid = el.getAttribute('data-testid');
+            if (testid) {
+                sel = `[data-testid="${testid}"]`;
+                testIds.push(sel);
+                keyBase = testid;
+            }
+            else {
+                const name = el.getAttribute('name');
+                if (name) {
+                    sel = `${el.tagName.toLowerCase()}[name="${name}"]`;
+                    names.push(sel);
+                    keyBase = name;
+                }
+                else {
+                    const role = el.getAttribute('role') || defaultRole(el);
+                    if (role) {
+                        const label = el.getAttribute('aria-label') || el.innerText.trim();
+                        if (label && label.length < 30) {
+                            const safe = label.replace(/\n+/g, ' ').trim();
+                            sel = `role=${role}[name="${safe}"]`;
+                            roles.push(sel);
+                            keyBase = safe.split(' ').slice(0, 3).join(' ');
+                        }
+                        else {
+                            sel = `role=${role}`;
+                            roles.push(sel);
+                            keyBase = role;
+                        }
+                    }
+                    else {
+                        const innerText = el.innerText.trim();
+                        if (innerText && innerText.length < 30) {
+                            const trimmed = innerText.replace(/\n+/g, ' ').trim();
+                            sel = `${el.tagName.toLowerCase()}:has-text("${trimmed}")`;
+                            text.push(sel);
+                            keyBase = trimmed.split(' ').slice(0, 3).join(' ');
+                        }
+                    }
+                }
+            }
+        }
+        if (sel) {
+            all.push(sel);
+            let prop = camel(keyBase || `${el.tagName.toLowerCase()}${index}`);
+            let suffix = 1;
+            while (pageObj[prop]) {
+                prop = `${prop}${suffix++}`;
+            }
+            pageObj[prop] = sel;
+        }
+        index++;
+    }
+    const unique = (arr) => Array.from(new Set(arr));
+    return {
+        ids: unique(ids),
+        testIds: unique(testIds),
+        names: unique(names),
+        roles: unique(roles),
+        text: unique(text),
+        all: unique(all),
+        pageObject: pageObj,
+    };
+}
 /**
  * Extracts DOM selectors from the given URL. The selectors are grouped by
  * the attribute or strategy used to locate them. Any error will result in an
@@ -39,114 +151,7 @@ async function extractSelectors(url) {
     try {
         await page.goto(url);
         // Collect selectors grouped by strategy inside the browser context
-        const groups = await page.evaluate(() => {
-            const ids = [];
-            const testIds = [];
-            const names = [];
-            const roles = [];
-            const text = [];
-            const all = [];
-            const pageObj = {};
-            const camel = (str) => str
-                .toLowerCase()
-                .replace(/[^a-z0-9]+(.)/g, (_, chr) => chr.toUpperCase());
-            const defaultRole = (el) => {
-                const tag = el.tagName.toLowerCase();
-                if (tag === 'a')
-                    return 'link';
-                if (tag === 'button')
-                    return 'button';
-                if (tag === 'select')
-                    return 'combobox';
-                if (tag === 'option')
-                    return 'option';
-                if (tag === 'input') {
-                    const type = (el.getAttribute('type') || '').toLowerCase();
-                    if (type === 'checkbox')
-                        return 'checkbox';
-                    if (type === 'radio')
-                        return 'radio';
-                    if (type === 'submit' || type === 'button')
-                        return 'button';
-                    return 'textbox';
-                }
-                return null;
-            };
-            const elements = Array.from(document.querySelectorAll('*'));
-            let index = 0;
-            for (const el of elements) {
-                let sel = '';
-                let keyBase = '';
-                if (el.id) {
-                    sel = `#${el.id}`;
-                    ids.push(sel);
-                    keyBase = el.id;
-                }
-                else {
-                    const testid = el.getAttribute('data-testid');
-                    if (testid) {
-                        sel = `[data-testid="${testid}"]`;
-                        testIds.push(sel);
-                        keyBase = testid;
-                    }
-                    else {
-                        const name = el.getAttribute('name');
-                        if (name) {
-                            sel = `${el.tagName.toLowerCase()}[name="${name}"]`;
-                            names.push(sel);
-                            keyBase = name;
-                        }
-                        else {
-                            const role = el.getAttribute('role') || defaultRole(el);
-                            if (role) {
-                                const label = el.getAttribute('aria-label') || el.innerText.trim();
-                                if (label && label.length < 30) {
-                                    const safe = label.replace(/\n+/g, ' ').trim();
-                                    sel = `role=${role}[name="${safe}"]`;
-                                    roles.push(sel);
-                                    keyBase = safe.split(' ').slice(0, 3).join(' ');
-                                }
-                                else {
-                                    sel = `role=${role}`;
-                                    roles.push(sel);
-                                    keyBase = role;
-                                }
-                            }
-                            else {
-                                const innerText = el.innerText.trim();
-                                if (innerText && innerText.length < 30) {
-                                    const trimmed = innerText.replace(/\n+/g, ' ').trim();
-                                    sel = `${el.tagName.toLowerCase()}:has-text("${trimmed}")`;
-                                    text.push(sel);
-                                    keyBase = trimmed.split(' ').slice(0, 3).join(' ');
-                                }
-                            }
-                        }
-                    }
-                }
-                if (sel) {
-                    all.push(sel);
-                    let prop = camel(keyBase || `${el.tagName.toLowerCase()}${index}`);
-                    let suffix = 1;
-                    while (pageObj[prop]) {
-                        prop = `${prop}${suffix++}`;
-                    }
-                    pageObj[prop] = sel;
-                }
-                index++;
-            }
-            // Remove duplicates and return grouped selectors
-            const unique = (arr) => Array.from(new Set(arr));
-            return {
-                ids: unique(ids),
-                testIds: unique(testIds),
-                names: unique(names),
-                roles: unique(roles),
-                text: unique(text),
-                all: unique(all),
-                pageObject: pageObj,
-            };
-        });
+        const groups = await page.evaluate(collectSelectors);
         const screenshotPath = path_1.default.join(process.cwd(), `screenshot-${Date.now()}.png`);
         await page.screenshot({ path: screenshotPath, fullPage: true });
         console.log(chalk.green(`Screenshot saved to ${screenshotPath}`));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,19 @@
 import path from 'path';
+import type { chromium as chromiumType } from 'playwright';
 
 // Lazily require dependencies so we can show a helpful message when they are
 // missing (common when `npm install` hasn't been run yet).
-let chromium: any;
-let chalk: any;
+let chromium: typeof chromiumType;
+
+interface ChalkLike {
+  blue(s: string): string;
+  green(s: string): string;
+  yellow(s: string): string;
+  magenta(s: string): string;
+  cyan(s: string): string;
+}
+
+let chalk: ChalkLike;
 
 try {
   ({ chromium } = require('playwright'));
@@ -15,7 +25,7 @@ try {
 }
 
 try {
-  chalk = require('chalk');
+  chalk = require('chalk') as ChalkLike;
 } catch {
   chalk = {
     blue: (s: string) => s,
@@ -55,6 +65,120 @@ export interface ExtractResult extends SelectorGroups {
   pageObject: PageObject;
 }
 
+function collectSelectors(): ExtractResult {
+  const ids: string[] = [];
+  const testIds: string[] = [];
+  const names: string[] = [];
+  const roles: string[] = [];
+  const text: string[] = [];
+  const all: string[] = [];
+  const pageObj: PageObject = {};
+
+  const camel = (str: string) =>
+    str.toLowerCase().replace(/[^a-z0-9]+(.)/g, (_, chr) => chr.toUpperCase());
+
+  function defaultRole(el: HTMLElement): string | null {
+    const tag = el.tagName.toLowerCase();
+    switch (tag) {
+      case 'a':
+        return 'link';
+      case 'button':
+        return 'button';
+      case 'select':
+        return 'combobox';
+      case 'option':
+        return 'option';
+      case 'input': {
+        const type = (el.getAttribute('type') || '').toLowerCase();
+        switch (type) {
+          case 'checkbox':
+            return 'checkbox';
+          case 'radio':
+            return 'radio';
+          case 'submit':
+          case 'button':
+            return 'button';
+          default:
+            return 'textbox';
+        }
+      }
+      default:
+        return null;
+    }
+  }
+
+  const elements = Array.from(document.querySelectorAll('*')) as HTMLElement[];
+  let index = 0;
+  for (const el of elements) {
+    let sel = '';
+    let keyBase = '';
+    if (el.id) {
+      sel = `#${el.id}`;
+      ids.push(sel);
+      keyBase = el.id;
+    } else {
+      const testid = el.getAttribute('data-testid');
+      if (testid) {
+        sel = `[data-testid="${testid}"]`;
+        testIds.push(sel);
+        keyBase = testid;
+      } else {
+        const name = el.getAttribute('name');
+        if (name) {
+          sel = `${el.tagName.toLowerCase()}[name="${name}"]`;
+          names.push(sel);
+          keyBase = name;
+        } else {
+          const role = el.getAttribute('role') || defaultRole(el);
+          if (role) {
+            const label = el.getAttribute('aria-label') || el.innerText.trim();
+            if (label && label.length < 30) {
+              const safe = label.replace(/\n+/g, ' ').trim();
+              sel = `role=${role}[name="${safe}"]`;
+              roles.push(sel);
+              keyBase = safe.split(' ').slice(0, 3).join(' ');
+            } else {
+              sel = `role=${role}`;
+              roles.push(sel);
+              keyBase = role;
+            }
+          } else {
+            const innerText = el.innerText.trim();
+            if (innerText && innerText.length < 30) {
+              const trimmed = innerText.replace(/\n+/g, ' ').trim();
+              sel = `${el.tagName.toLowerCase()}:has-text("${trimmed}")`;
+              text.push(sel);
+              keyBase = trimmed.split(' ').slice(0, 3).join(' ');
+            }
+          }
+        }
+      }
+    }
+
+    if (sel) {
+      all.push(sel);
+      let prop = camel(keyBase || `${el.tagName.toLowerCase()}${index}`);
+      let suffix = 1;
+      while (pageObj[prop]) {
+        prop = `${prop}${suffix++}`;
+      }
+      pageObj[prop] = sel;
+    }
+    index++;
+  }
+
+  const unique = (arr: string[]) => Array.from(new Set(arr));
+  return {
+    ids: unique(ids),
+    testIds: unique(testIds),
+    names: unique(names),
+    roles: unique(roles),
+    text: unique(text),
+    all: unique(all),
+    pageObject: pageObj,
+  };
+}
+
 /**
  * Extracts DOM selectors from the given URL. The selectors are grouped by
  * the attribute or strategy used to locate them. Any error will result in an
@@ -66,108 +190,7 @@ export async function extractSelectors(url: string): Promise<ExtractResult> {
   try {
     await page.goto(url);
     // Collect selectors grouped by strategy inside the browser context
-    const groups = await page.evaluate(() => {
-      const ids: string[] = [];
-      const testIds: string[] = [];
-      const names: string[] = [];
-      const roles: string[] = [];
-      const text: string[] = [];
-      const all: string[] = [];
-      const pageObj: Record<string, string> = {};
-
-      const camel = (str: string) =>
-        str
-          .toLowerCase()
-          .replace(/[^a-z0-9]+(.)/g, (_, chr) => chr.toUpperCase());
-
-      const defaultRole = (el: HTMLElement): string | null => {
-        const tag = el.tagName.toLowerCase();
-        if (tag === 'a') return 'link';
-        if (tag === 'button') return 'button';
-        if (tag === 'select') return 'combobox';
-        if (tag === 'option') return 'option';
-        if (tag === 'input') {
-          const type = (el.getAttribute('type') || '').toLowerCase();
-          if (type === 'checkbox') return 'checkbox';
-          if (type === 'radio') return 'radio';
-          if (type === 'submit' || type === 'button') return 'button';
-          return 'textbox';
-        }
-        return null;
-      };
-
-      const elements = Array.from(document.querySelectorAll('*')) as HTMLElement[];
-      let index = 0;
-      for (const el of elements) {
-        let sel = '';
-        let keyBase = '';
-        if (el.id) {
-          sel = `#${el.id}`;
-          ids.push(sel);
-          keyBase = el.id;
-        } else {
-          const testid = el.getAttribute('data-testid');
-          if (testid) {
-            sel = `[data-testid="${testid}"]`;
-            testIds.push(sel);
-            keyBase = testid;
-          } else {
-            const name = el.getAttribute('name');
-            if (name) {
-              sel = `${el.tagName.toLowerCase()}[name="${name}"]`;
-              names.push(sel);
-              keyBase = name;
-            } else {
-              const role = el.getAttribute('role') || defaultRole(el);
-              if (role) {
-                const label = el.getAttribute('aria-label') || el.innerText.trim();
-                if (label && label.length < 30) {
-                  const safe = label.replace(/\n+/g, ' ').trim();
-                  sel = `role=${role}[name="${safe}"]`;
-                  roles.push(sel);
-                  keyBase = safe.split(' ').slice(0, 3).join(' ');
-                } else {
-                  sel = `role=${role}`;
-                  roles.push(sel);
-                  keyBase = role;
-                }
-              } else {
-                const innerText = el.innerText.trim();
-                if (innerText && innerText.length < 30) {
-                  const trimmed = innerText.replace(/\n+/g, ' ').trim();
-                  sel = `${el.tagName.toLowerCase()}:has-text("${trimmed}")`;
-                  text.push(sel);
-                  keyBase = trimmed.split(' ').slice(0, 3).join(' ');
-                }
-              }
-            }
-          }
-        }
-
-        if (sel) {
-          all.push(sel);
-          let prop = camel(keyBase || `${el.tagName.toLowerCase()}${index}`);
-          let suffix = 1;
-          while (pageObj[prop]) {
-            prop = `${prop}${suffix++}`;
-          }
-          pageObj[prop] = sel;
-        }
-        index++;
-      }
-
-      // Remove duplicates and return grouped selectors
-      const unique = (arr: string[]) => Array.from(new Set(arr));
-      return {
-        ids: unique(ids),
-        testIds: unique(testIds),
-        names: unique(names),
-        roles: unique(roles),
-        text: unique(text),
-        all: unique(all),
-        pageObject: pageObj,
-      };
-    });
+    const groups = await page.evaluate(collectSelectors);
 
     const screenshotPath = path.join(
       process.cwd(),


### PR DESCRIPTION
## Summary
- factor out DOM traversal into dedicated `collectSelectors` helper
- tighten typings for Playwright and chalk dependencies
- ignore local dependencies with `.gitignore`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895abfb02d48330a228183e45a0b726